### PR TITLE
fix(leaderboard): handle userID capital field, add async/await to GamificationViewModel

### DIFF
--- a/GN1Swift/Components/LeaderboardRowView.swift
+++ b/GN1Swift/Components/LeaderboardRowView.swift
@@ -23,23 +23,13 @@ struct LeaderboardRowView: View {
             
             // User Info
             VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text("Level \(player.level)")
-                        .font(.custom("Poppins-SemiBold", size: 14))
-                        .foregroundColor(.primaryBrand)
-                    
-                    Spacer()
-                }
-                
-                if isCurrentUser {
-                    Text("You")
-                        .font(.custom("Poppins-Regular", size: 12))
-                        .foregroundColor(.textSecondary)
-                } else {
-                    Text("\(player.unlockedBadgesCount) badges")
-                        .font(.custom("Poppins-Regular", size: 12))
-                        .foregroundColor(.textSecondary)
-                }
+                Text(isCurrentUser ? "You" : (player.displayName.isEmpty ? "User" : player.displayName))
+                    .font(.custom("Poppins-SemiBold", size: 14))
+                    .foregroundColor(.textPrimary)
+
+                Text("Lv.\(player.level) · \(player.unlockedBadgesCount) badges")
+                    .font(.custom("Poppins-Regular", size: 12))
+                    .foregroundColor(.textSecondary)
             }
             
             Spacer()

--- a/GN1Swift/Model/UserGamification.swift
+++ b/GN1Swift/Model/UserGamification.swift
@@ -61,15 +61,16 @@ struct StreakInfo: Codable {
 
 struct UserGamification: Codable {
     let userId: String
+    var displayName: String = ""
     var points: Int = 0
     var level: Int = 1
     var totalXP: Int = 0
     var badges: [Badge] = []
     var streakInfo: StreakInfo = StreakInfo()
     var lastGamificationUpdate: Date = Date()
-    
+
     enum CodingKeys: String, CodingKey {
-        case userId, points, level, totalXP, badges
+        case userId, displayName, points, level, totalXP, badges
         case streakInfo, lastGamificationUpdate
     }
     
@@ -97,6 +98,7 @@ struct UserGamification: Codable {
 
     init(
         userId: String,
+        displayName: String = "",
         points: Int = 0,
         level: Int = 1,
         totalXP: Int = 0,
@@ -105,6 +107,7 @@ struct UserGamification: Codable {
         lastGamificationUpdate: Date = Date()
     ) {
         self.userId = userId
+        self.displayName = displayName
         self.points = points
         self.level = level
         self.totalXP = totalXP
@@ -135,6 +138,7 @@ struct UserGamification: Codable {
     
     init(from dict: [String: Any]) {
         self.userId = dict["userId"] as? String ?? ""
+        self.displayName = dict["displayName"] as? String ?? ""
         self.points = dict["points"] as? Int ?? 0
         self.level = dict["level"] as? Int ?? 1
         self.totalXP = dict["totalXP"] as? Int ?? 0

--- a/GN1Swift/Model/UserGamification.swift
+++ b/GN1Swift/Model/UserGamification.swift
@@ -137,7 +137,7 @@ struct UserGamification: Codable {
     }
     
     init(from dict: [String: Any]) {
-        self.userId = dict["userId"] as? String ?? ""
+        self.userId = dict["userId"] as? String ?? dict["userID"] as? String ?? ""
         self.displayName = dict["displayName"] as? String ?? ""
         self.points = dict["points"] as? Int ?? 0
         self.level = dict["level"] as? Int ?? 1

--- a/GN1Swift/ViewModels/GamificationViewModel.swift
+++ b/GN1Swift/ViewModels/GamificationViewModel.swift
@@ -8,11 +8,23 @@ class GamificationViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published var topPlayers: [UserGamification] = []
     @Published var recentAchievement: (badge: Badge, points: Int)? = nil
-    
+
     private let facade: AppFacadeType
-    
+    private var authListener: AuthStateDidChangeListenerHandle?
+
     init(facade: AppFacadeType = AppFacade.shared) {
         self.facade = facade
+        authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
+            guard let self, user != nil else { return }
+            self.loadGamificationProfile()
+            self.loadTopPlayers()
+        }
+    }
+
+    deinit {
+        if let handle = authListener {
+            Auth.auth().removeStateDidChangeListener(handle)
+        }
     }
     
     func loadGamificationProfile() {

--- a/GN1Swift/ViewModels/GamificationViewModel.swift
+++ b/GN1Swift/ViewModels/GamificationViewModel.swift
@@ -16,8 +16,12 @@ class GamificationViewModel: ObservableObject {
         self.facade = facade
         authListener = Auth.auth().addStateDidChangeListener { [weak self] _, user in
             guard let self, user != nil else { return }
-            self.loadGamificationProfile()
-            self.loadTopPlayers()
+            Task { [weak self] in
+                guard let self else { return }
+                async let profileLoad: Void = self.fetchAndCacheProfile()
+                async let leaderboardLoad: Void = self.fetchAndCacheLeaderboard()
+                _ = await (profileLoad, leaderboardLoad)
+            }
         }
     }
 
@@ -26,149 +30,141 @@ class GamificationViewModel: ObservableObject {
             Auth.auth().removeStateDidChangeListener(handle)
         }
     }
-    
+
+
     func loadGamificationProfile() {
-        guard let userId = Auth.auth().currentUser?.uid else {
-            errorMessage = "User not authenticated"
-            // Try to load from disk cache for offline support
-            if let diskCached = GamificationCacheManager.shared.loadCachedProfile() {
-                self.gamification = diskCached
-            }
-            return
-        }
-        
-        isLoading = true
-        errorMessage = nil
-        
-        // L1: Try memory cache first (instant)
-        if let memCached = GamificationMemoryCache.shared.getProfile(forKey: userId) {
-            DispatchQueue.main.async { [weak self] in
-                self?.gamification = memCached
-            }
-        } else if let diskCached = GamificationCacheManager.shared.loadCachedProfile() {
-            DispatchQueue.main.async { [weak self] in
-                self?.gamification = diskCached
-            }
-        }
-        
-        // Check if cache is still valid (smart invalidation)
-        let cacheValid = GamificationCacheInvalidation.shared.isProfileCacheValid()
-        
-        if cacheValid {
-            // Cache is fresh enough, no need to fetch
-            DispatchQueue.main.async { [weak self] in
-                self?.isLoading = false
-            }
-            return
-        }
-        
-        // Fetch fresh data from cloud
-        facade.fetchGamificationProfile(userId: userId) { [weak self] profile in
-            DispatchQueue.main.async {
-                self?.isLoading = false
-                if let profile = profile {
-                    // Check if profile actually changed before updating
-                    let hasChanged = GamificationCacheInvalidation.shared.hasProfileChanged(profile)
-                    
-                    if hasChanged {
-                        self?.gamification = profile
-                    }
-                    
-                    // Cache in all levels
-                    GamificationMemoryCache.shared.setProfile(profile, forKey: userId)
-                    GamificationCacheManager.shared.saveProfile(profile)
-                    GamificationCacheInvalidation.shared.saveProfileMetadata(profile)
-                } else {
-                    // Use cached or create default
-                    if let memCached = GamificationMemoryCache.shared.getProfile(forKey: userId) {
-                        self?.gamification = memCached
-                    } else if let diskCached = GamificationCacheManager.shared.loadCachedProfile() {
-                        self?.gamification = diskCached
-                    } else {
-                        self?.gamification = UserGamification(userId: userId)
-                    }
-                }
-            }
-        }
+        Task { [weak self] in await self?.fetchAndCacheProfile() }
     }
-    
+
     func loadTopPlayers() {
-        isLoading = true
-        
-        // L1: Try memory cache first (instant)
-        if let memCached = GamificationMemoryCache.shared.getLeaderboard() {
-            DispatchQueue.main.async { [weak self] in
-                self?.topPlayers = memCached
-            }
-        } else if let diskCached = GamificationCacheManager.shared.loadCachedLeaderboard() {
-            DispatchQueue.main.async { [weak self] in
-                self?.topPlayers = diskCached
-            }
-        }
-        
-        // Check if cache is still valid (smart invalidation)
-        let cacheValid = GamificationCacheInvalidation.shared.isLeaderboardCacheValid()
-        
-        if cacheValid {
-            // Cache is fresh enough, no need to fetch
-            DispatchQueue.main.async { [weak self] in
-                self?.isLoading = false
+        Task { [weak self] in await self?.fetchAndCacheLeaderboard() }
+    }
+
+    // MARK: - Core async: perfil
+
+    private func fetchAndCacheProfile() async {
+        guard let userId = Auth.auth().currentUser?.uid else {
+            if let diskCached = GamificationCacheManager.shared.loadCachedProfile() {
+                await MainActor.run { self.gamification = diskCached }
             }
             return
         }
-        
-        // Fetch fresh data
-        facade.fetchLeaderboard { [weak self] players in
-            DispatchQueue.main.async {
-                self?.isLoading = false
-                if !players.isEmpty {
-                    // Check if leaderboard actually changed before updating
-                    let hasChanged = GamificationCacheInvalidation.shared.hasLeaderboardChanged(players)
-                    
-                    if hasChanged {
-                        self?.topPlayers = players
-                    }
-                    
-                    // Cache in all levels
-                    GamificationMemoryCache.shared.setLeaderboard(players)
-                    GamificationCacheManager.shared.saveLeaderboard(players)
-                    GamificationCacheInvalidation.shared.saveLeaderboardMetadata(players)
-                } else {
-                    // Use cached if fresh fetch failed
-                    if let memCached = GamificationMemoryCache.shared.getLeaderboard() {
-                        self?.topPlayers = memCached
-                    } else if let diskCached = GamificationCacheManager.shared.loadCachedLeaderboard() {
-                        self?.topPlayers = diskCached
-                    }
+
+        await MainActor.run {
+            self.isLoading = true
+            self.errorMessage = nil
+        }
+
+        // L1
+        if let memCached = GamificationMemoryCache.shared.getProfile(forKey: userId) {
+            await MainActor.run { self.gamification = memCached }
+        } else if let diskCached = GamificationCacheManager.shared.loadCachedProfile() {
+            await MainActor.run { self.gamification = diskCached }
+        }
+
+        guard !GamificationCacheInvalidation.shared.isProfileCacheValid() else {
+            await MainActor.run { self.isLoading = false }
+            return
+        }
+
+        let profile: UserGamification? = await withCheckedContinuation { continuation in
+            facade.fetchGamificationProfile(userId: userId) { continuation.resume(returning: $0) }
+        }
+
+        if let profile {
+            let hasChanged: Bool = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .utility).async {
+                    continuation.resume(
+                        returning: GamificationCacheInvalidation.shared.hasProfileChanged(profile)
+                    )
                 }
+            }
+
+            await MainActor.run {
+                if hasChanged { self.gamification = profile }
+                GamificationMemoryCache.shared.setProfile(profile, forKey: userId)
+                GamificationCacheManager.shared.saveProfile(profile)
+                GamificationCacheInvalidation.shared.saveProfileMetadata(profile)
+                self.isLoading = false
+            }
+        } else {
+            await MainActor.run {
+                self.gamification = GamificationMemoryCache.shared.getProfile(forKey: userId)
+                    ?? GamificationCacheManager.shared.loadCachedProfile()
+                    ?? UserGamification(userId: userId)
+                self.isLoading = false
             }
         }
     }
-    
-    func refreshStreakStatus() {
-        guard let gamification = gamification else { return }
-        
-        let calendar = Calendar.current
-        let now = Date()
-        
-        guard let lastActivityDate = gamification.streakInfo.lastActivityDate else {
+
+    // MARK: - Core async: leaderboard
+
+    private func fetchAndCacheLeaderboard() async {
+        await MainActor.run { self.isLoading = true }
+
+        if let memCached = GamificationMemoryCache.shared.getLeaderboard() {
+            await MainActor.run { self.topPlayers = memCached }
+        } else if let diskCached = GamificationCacheManager.shared.loadCachedLeaderboard() {
+            await MainActor.run { self.topPlayers = diskCached }
+        }
+
+        guard !GamificationCacheInvalidation.shared.isLeaderboardCacheValid() else {
+            await MainActor.run { self.isLoading = false }
             return
         }
-        
-        let daysSinceActivity = calendar.dateComponents([.day], from: lastActivityDate, to: now).day ?? 0
-        
+
+        let players: [UserGamification] = await withCheckedContinuation { continuation in
+            facade.fetchLeaderboard { continuation.resume(returning: $0) }
+        }
+
+        if !players.isEmpty {
+            let hasChanged: Bool = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .utility).async {
+                    continuation.resume(
+                        returning: GamificationCacheInvalidation.shared.hasLeaderboardChanged(players)
+                    )
+                }
+            }
+
+            await MainActor.run {
+                if hasChanged { self.topPlayers = players }
+                GamificationMemoryCache.shared.setLeaderboard(players)
+                GamificationCacheManager.shared.saveLeaderboard(players)
+                GamificationCacheInvalidation.shared.saveLeaderboardMetadata(players)
+                self.isLoading = false
+            }
+        } else {
+            await MainActor.run {
+                self.topPlayers = GamificationMemoryCache.shared.getLeaderboard()
+                    ?? GamificationCacheManager.shared.loadCachedLeaderboard()
+                    ?? []
+                self.isLoading = false
+            }
+        }
+    }
+
+    // MARK: - Streak
+
+    func refreshStreakStatus() {
+        guard let gamification else { return }
+        guard let lastActivityDate = gamification.streakInfo.lastActivityDate else { return }
+        let daysSinceActivity = Calendar.current
+            .dateComponents([.day], from: lastActivityDate, to: Date()).day ?? 0
         if daysSinceActivity > 1 {
-            // Streak broken
             var updated = gamification
             updated.streakInfo.currentStreak = 0
             self.gamification = updated
         }
     }
-    
+
+    // MARK: - Achievement
+
     func showAchievement(_ badge: Badge, points: Int) {
         recentAchievement = (badge: badge, points: points)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self] in
-            self?.recentAchievement = nil
+        // Task.sleep reemplaza DispatchQueue.main.asyncAfter
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 4_000_000_000)
+            await MainActor.run { self?.recentAchievement = nil }
         }
     }
 }


### PR DESCRIPTION
Refactors GamificationViewModel to use async/await with Task and explicit DispatchQueue.global for SHA256 hashing. 
Fixes leaderboard showing duplicate entries due to userID/userId field inconsistency, adds player display names by joining with users collection, and resolves Cloud Run 401 errors on getGamificationProfile and getLeaderboard by adding invoker public. 
Reduces cache TTL to improve data freshness during development.