### PR TITLE
fix(weather, cache): resolve asyncAfter race condition and stale cach…

### DIFF
--- a/GN1Swift/CoreData/RideLocalDataSource.swift
+++ b/GN1Swift/CoreData/RideLocalDataSource.swift
@@ -32,7 +32,6 @@ final class RideLocalDataSource {
     /// Rides with status "pending" (locally created while offline) are preserved.
     /// Uses a background context so the main thread is never blocked.
     func saveRides(_ rides: [Ride]) async {
-        guard !rides.isEmpty else { return }
         let context = persistence.newBackgroundContext()
 
         await context.perform {

--- a/GN1Swift/Services/CloudFuntionsService.swift
+++ b/GN1Swift/Services/CloudFuntionsService.swift
@@ -62,8 +62,8 @@ final class CloudFunctionsService {
 
     // MARK: - Weather
 
-    func updateWeather() {
-        functions.httpsCallable("weatherAwareRides").call { _, _ in }
+    func updateWeather(completion: @escaping () -> Void = {}) {
+        functions.httpsCallable("weatherAwareRides").call { _, _ in completion() }
     }
 
     // MARK: - Rides — Passenger

--- a/GN1Swift/Views/HomeView.swift
+++ b/GN1Swift/Views/HomeView.swift
@@ -299,8 +299,7 @@ struct HomeView: View {
     // MARK: - Weather (unchanged)
 
     private func loadWeatherFromCloud() {
-        CloudFunctionsService.shared.updateWeather()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+        CloudFunctionsService.shared.updateWeather {
             FirestoreService.shared.loadWeather { data in
                 DispatchQueue.main.async {
                     guard let w = data else {


### PR DESCRIPTION


CHANGED FILES
Services/CloudFuntionsService.swift
  - updateWeather() now accepts an optional completion handler (default no-op)
  - Backward compatible: existing call sites with no argument still compile
  - Enables callers to sequence work after the CF write finishes

Views/HomeView.swift
  - Replaced DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) with updateWeather completion handler
  - Firestore read of analytics_cache/weatherDemand now fires only after weatherAwareRides confirms it has finished writing — eliminates the race condition where a slow network caused the UI to read stale weather data

CoreData/RideLocalDataSource.swift
  - Removed guard !rides.isEmpty early return from saveRides(_:)
  - An empty array from Firebase now correctly executes the NSBatchDeleteRequest and clears non-pending cached rides instead of leaving stale data on screen