### PR TITLE
Feat/sprint4 analytics search favorites bq

### DIFF
--- a/GN1Swift/Services/AnalyticsCacheService.swift
+++ b/GN1Swift/Services/AnalyticsCacheService.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// MARK: - Cached wrapper objects (NSObject required by NSCache)
+
+final class CachedZoneAnalytics: NSObject {
+    let zones: [String: Int]
+    let mostDemandedZone: String
+    let timestamp: Date
+
+    init(zones: [String: Int], mostDemandedZone: String) {
+        self.zones = zones
+        self.mostDemandedZone = mostDemandedZone
+        self.timestamp = Date()
+    }
+}
+
+final class CachedPeakHoursAnalytics: NSObject {
+    let hours: [Int: Int]
+    let morningPeak: Int?
+    let eveningPeak: Int?
+    let timestamp: Date
+
+    init(hours: [Int: Int], morningPeak: Int?, eveningPeak: Int?) {
+        self.hours = hours
+        self.morningPeak = morningPeak
+        self.eveningPeak = eveningPeak
+        self.timestamp = Date()
+    }
+}
+
+// MARK: - Cache service with TTL
+
+final class AnalyticsCacheService {
+    static let shared = AnalyticsCacheService()
+    private init() {}
+
+    private let ttl: TimeInterval = 300  // 5 minutes
+
+    private let zonesCache     = NSCache<NSString, CachedZoneAnalytics>()
+    private let peakHoursCache = NSCache<NSString, CachedPeakHoursAnalytics>()
+
+    private let zonesKey: NSString     = "topZones"
+    private let peakHoursKey: NSString = "peakHours"
+
+    // MARK: - Zone Analytics
+
+    func zoneAnalytics() -> CachedZoneAnalytics? {
+        guard let cached = zonesCache.object(forKey: zonesKey),
+              Date().timeIntervalSince(cached.timestamp) < ttl else { return nil }
+        return cached
+    }
+
+    func setZoneAnalytics(zones: [String: Int], mostDemandedZone: String) {
+        let obj = CachedZoneAnalytics(zones: zones, mostDemandedZone: mostDemandedZone)
+        zonesCache.setObject(obj, forKey: zonesKey)
+    }
+
+    // MARK: - Peak Hours Analytics
+
+    func peakHoursAnalytics() -> CachedPeakHoursAnalytics? {
+        guard let cached = peakHoursCache.object(forKey: peakHoursKey),
+              Date().timeIntervalSince(cached.timestamp) < ttl else { return nil }
+        return cached
+    }
+
+    func setPeakHoursAnalytics(hours: [Int: Int], morningPeak: Int?, eveningPeak: Int?) {
+        let obj = CachedPeakHoursAnalytics(hours: hours, morningPeak: morningPeak, eveningPeak: eveningPeak)
+        peakHoursCache.setObject(obj, forKey: peakHoursKey)
+    }
+
+    func invalidateAll() {
+        zonesCache.removeAllObjects()
+        peakHoursCache.removeAllObjects()
+    }
+}

--- a/GN1Swift/Services/CloudFuntionsService.swift
+++ b/GN1Swift/Services/CloudFuntionsService.swift
@@ -66,6 +66,16 @@ final class CloudFunctionsService {
         functions.httpsCallable("weatherAwareRides").call { _, _ in }
     }
 
+    // MARK: - Analytics
+
+    func calculateTopZones(completion: @escaping () -> Void = {}) {
+        functions.httpsCallable("calculateTopZones").call { _, _ in completion() }
+    }
+
+    func calculatePeakHours(completion: @escaping () -> Void = {}) {
+        functions.httpsCallable("calculatePeakHours").call { _, _ in completion() }
+    }
+
     // MARK: - Rides — Passenger
 
     func getAllAvailableRides(completion: @escaping ([Ride]) -> Void) {

--- a/GN1Swift/Services/FavoritePersistenceController.swift
+++ b/GN1Swift/Services/FavoritePersistenceController.swift
@@ -1,0 +1,44 @@
+import CoreData
+
+final class FavoritePersistenceController {
+    static let shared = FavoritePersistenceController()
+
+    private let container: NSPersistentContainer
+
+    var viewContext: NSManagedObjectContext { container.viewContext }
+    func backgroundContext() -> NSManagedObjectContext { container.newBackgroundContext() }
+
+    private init() {
+        let entity = NSEntityDescription()
+        entity.name = "FavoriteRouteEntity"
+        entity.managedObjectClassName = "NSManagedObject"
+        entity.properties = [
+            favAttr("id",          .stringAttributeType),
+            favAttr("origin",      .stringAttributeType),
+            favAttr("destination", .stringAttributeType),
+            favAttr("zone",        .stringAttributeType),
+            favAttr("useCount",    .integer32AttributeType),
+            favAttr("savedAt",     .dateAttributeType)
+        ]
+
+        let model = NSManagedObjectModel()
+        model.entities = [entity]
+
+        container = NSPersistentContainer(name: "FavoritesModel", managedObjectModel: model)
+        container.loadPersistentStores { desc, error in
+            if let error = error {
+                print("[FavoritesDB] Load error:", error.localizedDescription)
+                if let url = desc.url { try? FileManager.default.removeItem(at: url) }
+            }
+        }
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+}
+
+private func favAttr(_ name: String, _ type: NSAttributeType) -> NSAttributeDescription {
+    let a = NSAttributeDescription()
+    a.name = name
+    a.attributeType = type
+    a.isOptional = true
+    return a
+}

--- a/GN1Swift/Services/FavoriteRouteLocalDataSource.swift
+++ b/GN1Swift/Services/FavoriteRouteLocalDataSource.swift
@@ -1,0 +1,88 @@
+import CoreData
+
+struct FavoriteRoute: Identifiable {
+    let id: String
+    let origin: String
+    let destination: String
+    let zone: String
+    let useCount: Int
+    let savedAt: Date
+}
+
+final class FavoriteRouteLocalDataSource {
+    private let store = FavoritePersistenceController.shared
+
+    // MARK: - Read (view context — main thread safe)
+
+    func fetchAll() -> [FavoriteRoute] {
+        let ctx = store.viewContext
+        let req = NSFetchRequest<NSManagedObject>(entityName: "FavoriteRouteEntity")
+        req.sortDescriptors = [NSSortDescriptor(key: "useCount", ascending: false)]
+        return ((try? ctx.fetch(req)) ?? []).compactMap { obj in
+            guard let id = obj.value(forKey: "id") as? String,
+                  let origin = obj.value(forKey: "origin") as? String,
+                  let destination = obj.value(forKey: "destination") as? String else { return nil }
+            return FavoriteRoute(
+                id: id,
+                origin: origin,
+                destination: destination,
+                zone: obj.value(forKey: "zone") as? String ?? "",
+                useCount: obj.value(forKey: "useCount") as? Int ?? 0,
+                savedAt: obj.value(forKey: "savedAt") as? Date ?? Date()
+            )
+        }
+    }
+
+    // MARK: - Write (background context)
+
+    func save(origin: String, destination: String, zone: String,
+              completion: @escaping () -> Void = {}) {
+        let ctx = store.backgroundContext()
+        ctx.perform {
+            let req = NSFetchRequest<NSManagedObject>(entityName: "FavoriteRouteEntity")
+            req.predicate = NSPredicate(format: "origin == %@ AND destination == %@", origin, destination)
+            req.fetchLimit = 1
+            if let existing = (try? ctx.fetch(req))?.first {
+                let count = existing.value(forKey: "useCount") as? Int32 ?? 0
+                existing.setValue(count + 1, forKey: "useCount")
+                existing.setValue(zone, forKey: "zone")
+            } else {
+                let obj = NSEntityDescription.insertNewObject(forEntityName: "FavoriteRouteEntity", into: ctx)
+                obj.setValue(UUID().uuidString, forKey: "id")
+                obj.setValue(origin,            forKey: "origin")
+                obj.setValue(destination,       forKey: "destination")
+                obj.setValue(zone,              forKey: "zone")
+                obj.setValue(Int32(1),          forKey: "useCount")
+                obj.setValue(Date(),            forKey: "savedAt")
+            }
+            try? ctx.save()
+            DispatchQueue.main.async { completion() }
+        }
+    }
+
+    func incrementUseCount(id: String, completion: @escaping () -> Void = {}) {
+        let ctx = store.backgroundContext()
+        ctx.perform {
+            let req = NSFetchRequest<NSManagedObject>(entityName: "FavoriteRouteEntity")
+            req.predicate = NSPredicate(format: "id == %@", id)
+            req.fetchLimit = 1
+            if let obj = (try? ctx.fetch(req))?.first {
+                let count = obj.value(forKey: "useCount") as? Int32 ?? 0
+                obj.setValue(count + 1, forKey: "useCount")
+                try? ctx.save()
+            }
+            DispatchQueue.main.async { completion() }
+        }
+    }
+
+    func delete(id: String, completion: @escaping () -> Void = {}) {
+        let ctx = store.backgroundContext()
+        ctx.perform {
+            let req = NSFetchRequest<NSManagedObject>(entityName: "FavoriteRouteEntity")
+            req.predicate = NSPredicate(format: "id == %@", id)
+            (try? ctx.fetch(req))?.forEach { ctx.delete($0) }
+            try? ctx.save()
+            DispatchQueue.main.async { completion() }
+        }
+    }
+}

--- a/GN1Swift/Services/FirestoreService.swift
+++ b/GN1Swift/Services/FirestoreService.swift
@@ -76,6 +76,42 @@ final class FirestoreService {
         }
     }
 
+    // MARK: - Analytics Cache
+
+    func fetchZoneAnalytics(completion: @escaping (CachedZoneAnalytics?) -> Void) {
+        db.collection("analytics_cache").document("topZones").getDocument { snapshot, _ in
+            guard let data = snapshot?.data() else { completion(nil); return }
+            let zones = data["zones"] as? [String: Int] ?? [:]
+            let mostDemanded = data["mostDemandedZone"] as? String ?? ""
+            completion(CachedZoneAnalytics(zones: zones, mostDemandedZone: mostDemanded))
+        }
+    }
+
+    func fetchPeakHoursAnalytics(completion: @escaping (CachedPeakHoursAnalytics?) -> Void) {
+        db.collection("analytics_cache").document("peakHours").getDocument { snapshot, _ in
+            guard let data = snapshot?.data() else { completion(nil); return }
+            // JS for..in yields string keys — normalize to [Int: Int]
+            let rawHours = data["hours"] as? [String: Int] ?? [:]
+            let hours = Dictionary(uniqueKeysWithValues: rawHours.compactMap { k, v -> (Int, Int)? in
+                guard let h = Int(k) else { return nil }
+                return (h, v)
+            })
+            let morningPeak: Int?
+            if let mp = data["morningPeak"] as? Int { morningPeak = mp }
+            else if let mp = data["morningPeak"] as? String { morningPeak = Int(mp) }
+            else { morningPeak = nil }
+
+            let eveningPeak: Int?
+            if let ep = data["eveningPeak"] as? Int { eveningPeak = ep }
+            else if let ep = data["eveningPeak"] as? String { eveningPeak = Int(ep) }
+            else { eveningPeak = nil }
+
+            completion(CachedPeakHoursAnalytics(hours: hours,
+                                                 morningPeak: morningPeak,
+                                                 eveningPeak: eveningPeak))
+        }
+    }
+
     // MARK: - Weather
 
     func loadWeather(completion: @escaping (WeatherData?) -> Void) {

--- a/GN1Swift/ViewModels/AnalyticsDashboardViewModel.swift
+++ b/GN1Swift/ViewModels/AnalyticsDashboardViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 final class AnalyticsDashboardViewModel: ObservableObject {
 

--- a/GN1Swift/ViewModels/AnalyticsDashboardViewModel.swift
+++ b/GN1Swift/ViewModels/AnalyticsDashboardViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+final class AnalyticsDashboardViewModel: ObservableObject {
+
+    @Published var zoneAnalytics: CachedZoneAnalytics?
+    @Published var peakHoursAnalytics: CachedPeakHoursAnalytics?
+    @Published var isLoading = false
+    @Published var isOffline = false
+    @Published var cacheHit = false
+    @Published var lastRefreshed: Date?
+
+    private let cache = AnalyticsCacheService.shared
+
+    // MARK: - Load
+
+    func load() {
+        let cachedZones = cache.zoneAnalytics()
+        let cachedPeak  = cache.peakHoursAnalytics()
+
+        // TTL still valid — serve instantly without any network call
+        if let z = cachedZones, let p = cachedPeak {
+            zoneAnalytics = z
+            peakHoursAnalytics = p
+            cacheHit = true
+            lastRefreshed = z.timestamp
+            return
+        }
+
+        isLoading = true
+        cacheHit  = false
+
+        // Fire both CF refresh + Firestore reads concurrently with async let
+        Task { [weak self] in
+            guard let self else { return }
+            async let zonesTask: Void = self.refreshZones()
+            async let peakTask: Void  = self.refreshPeakHours()
+            _ = await (zonesTask, peakTask)
+            await MainActor.run { self.isLoading = false }
+        }
+    }
+
+    func forceRefresh() {
+        cache.invalidateAll()
+        isLoading = true
+        cacheHit  = false
+        Task { [weak self] in
+            guard let self else { return }
+            async let zonesTask: Void = self.refreshZones()
+            async let peakTask: Void  = self.refreshPeakHours()
+            _ = await (zonesTask, peakTask)
+            await MainActor.run { self.isLoading = false }
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func refreshZones() async {
+        await withCheckedContinuation { continuation in
+            CloudFunctionsService.shared.calculateTopZones {
+                FirestoreService.shared.fetchZoneAnalytics { [weak self] result in
+                    guard let self else { continuation.resume(); return }
+                    DispatchQueue.main.async {
+                        if let r = result {
+                            self.cache.setZoneAnalytics(zones: r.zones,
+                                                        mostDemandedZone: r.mostDemandedZone)
+                            self.zoneAnalytics  = self.cache.zoneAnalytics()
+                            self.lastRefreshed  = Date()
+                            self.isOffline      = false
+                        } else {
+                            self.isOffline = true
+                        }
+                    }
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private func refreshPeakHours() async {
+        await withCheckedContinuation { continuation in
+            CloudFunctionsService.shared.calculatePeakHours {
+                FirestoreService.shared.fetchPeakHoursAnalytics { [weak self] result in
+                    guard let self else { continuation.resume(); return }
+                    DispatchQueue.main.async {
+                        if let r = result {
+                            self.cache.setPeakHoursAnalytics(hours: r.hours,
+                                                              morningPeak: r.morningPeak,
+                                                              eveningPeak: r.eveningPeak)
+                            self.peakHoursAnalytics = self.cache.peakHoursAnalytics()
+                        }
+                    }
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}

--- a/GN1Swift/ViewModels/FavoritesViewModel.swift
+++ b/GN1Swift/ViewModels/FavoritesViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 final class FavoritesViewModel: ObservableObject {
     @Published var favorites: [FavoriteRoute] = []

--- a/GN1Swift/ViewModels/FavoritesViewModel.swift
+++ b/GN1Swift/ViewModels/FavoritesViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class FavoritesViewModel: ObservableObject {
+    @Published var favorites: [FavoriteRoute] = []
+    private let dataSource = FavoriteRouteLocalDataSource()
+
+    func load() {
+        favorites = dataSource.fetchAll()
+    }
+
+    func save(origin: String, destination: String, zone: String) {
+        guard !origin.trimmingCharacters(in: .whitespaces).isEmpty,
+              !destination.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        dataSource.save(origin: origin, destination: destination, zone: zone) { [weak self] in
+            self?.load()
+        }
+    }
+
+    func delete(id: String) {
+        favorites.removeAll { $0.id == id }
+        dataSource.delete(id: id)
+    }
+
+    func apply(_ favorite: FavoriteRoute, to viewModel: CreateRideViewModel) {
+        viewModel.originText = favorite.origin
+        viewModel.destinationText = favorite.destination
+        viewModel.zone = favorite.zone
+        dataSource.incrementUseCount(id: favorite.id) { [weak self] in
+            self?.load()
+        }
+    }
+}

--- a/GN1Swift/ViewModels/SearchRidesViewModel.swift
+++ b/GN1Swift/ViewModels/SearchRidesViewModel.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Combine
+
+final class SearchRidesViewModel: ObservableObject {
+    @Published var query = ""
+    @Published var results: [Ride] = []
+    @Published var isFiltering = false
+
+    private let allRides: [Ride]
+    private var cancellables = Set<AnyCancellable>()
+
+    init(rides: [Ride]) {
+        self.allRides = rides
+        self.results = rides
+
+        $query
+            .debounce(for: .milliseconds(300), scheduler: RunLoop.main)
+            .removeDuplicates()
+            .sink { [weak self] q in self?.filterInBackground(query: q) }
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Background filtering
+
+    private func filterInBackground(query: String) {
+        let q = query.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !q.isEmpty else {
+            results = allRides
+            isFiltering = false
+            return
+        }
+        isFiltering = true
+        let rides = allRides
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let filtered = rides.filter { ride in
+                ride.origin.lowercased().contains(q)
+                    || ride.destination.lowercased().contains(q)
+                    || ride.zone.lowercased().contains(q)
+                    || ride.driverName.lowercased().contains(q)
+            }
+            DispatchQueue.main.async {
+                self?.results = filtered
+                self?.isFiltering = false
+            }
+        }
+    }
+}

--- a/GN1Swift/Views/AnalyticsDashboardView.swift
+++ b/GN1Swift/Views/AnalyticsDashboardView.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+struct AnalyticsDashboardView: View {
+
+    @StateObject private var vm = AnalyticsDashboardViewModel()
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .top) {
+                Color.backgroundApp.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    if vm.isOffline { offlineBanner }
+
+                    if vm.isLoading {
+                        Spacer()
+                        ProgressView("Loading analytics…")
+                        Spacer()
+                    } else {
+                        ScrollView {
+                            VStack(alignment: .leading, spacing: 20) {
+                                cacheStatusChip
+
+                                if let zones = vm.zoneAnalytics {
+                                    zonesSection(zones)
+                                }
+
+                                if let peak = vm.peakHoursAnalytics {
+                                    peakHoursSection(peak)
+                                }
+
+                                if vm.zoneAnalytics == nil && vm.peakHoursAnalytics == nil {
+                                    emptyState
+                                }
+                            }
+                            .padding(20)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Demand Analytics")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { vm.forceRefresh() } label: {
+                        Image(systemName: "arrow.clockwise")
+                            .foregroundColor(.primaryBrand)
+                    }
+                }
+            }
+            .onAppear { vm.load() }
+        }
+    }
+
+    // MARK: - Cache status chip
+
+    private var cacheStatusChip: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(vm.cacheHit ? Color.green : Color.primaryBrand)
+                .frame(width: 8, height: 8)
+            Text(vm.cacheHit ? "Served from cache" : "Live data")
+                .font(.custom("Poppins-Medium", size: 12))
+                .foregroundColor(.textSecondary)
+            if let ts = vm.lastRefreshed {
+                Text("· \(timeAgo(ts))")
+                    .font(.custom("Poppins-Regular", size: 12))
+                    .foregroundColor(.placeholderMuted)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color.surfaceCard)
+        .cornerRadius(20)
+    }
+
+    // MARK: - Top Zones
+
+    private func zonesSection(_ data: CachedZoneAnalytics) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Top Demand Zones")
+                    .font(.custom("Poppins-Bold", size: 18))
+                    .foregroundColor(.textPrimary)
+                Spacer()
+                Label(data.mostDemandedZone, systemImage: "mappin.circle.fill")
+                    .font(.custom("Poppins-Medium", size: 12))
+                    .foregroundColor(.primaryBrand)
+            }
+
+            let sorted = data.zones.sorted { $0.value > $1.value }
+            let maxCount = sorted.first?.value ?? 1
+
+            ForEach(sorted.prefix(6), id: \.key) { zone, count in
+                zoneBar(name: zone, count: count, max: maxCount,
+                        isTop: zone == data.mostDemandedZone)
+            }
+        }
+        .padding(16)
+        .background(Color.surfaceCard)
+        .cornerRadius(16)
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.borderLine, lineWidth: 1))
+    }
+
+    private func zoneBar(name: String, count: Int, max: Int, isTop: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(name)
+                    .font(.custom("Poppins-Medium", size: 13))
+                    .foregroundColor(.textPrimary)
+                if isTop {
+                    Text("TOP")
+                        .font(.custom("Poppins-Bold", size: 9))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(Color.primaryBrand)
+                        .cornerRadius(4)
+                }
+                Spacer()
+                Text("\(count) rides")
+                    .font(.custom("Poppins-Regular", size: 12))
+                    .foregroundColor(.textSecondary)
+            }
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color.borderLine)
+                        .frame(height: 8)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(isTop ? Color.primaryBrand : Color.primaryBrand.opacity(0.4))
+                        .frame(width: geo.size.width * CGFloat(count) / CGFloat(max), height: 8)
+                }
+            }
+            .frame(height: 8)
+        }
+    }
+
+    // MARK: - Peak Hours
+
+    private func peakHoursSection(_ data: CachedPeakHoursAnalytics) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Peak Hours")
+                .font(.custom("Poppins-Bold", size: 18))
+                .foregroundColor(.textPrimary)
+
+            HStack(spacing: 12) {
+                peakPill(label: "Morning Peak",
+                         hour: data.morningPeak,
+                         icon: "sunrise.fill",
+                         color: .orange)
+                peakPill(label: "Evening Peak",
+                         hour: data.eveningPeak,
+                         icon: "sunset.fill",
+                         color: .purple)
+            }
+
+            let maxCount = data.hours.values.max() ?? 1
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Hourly distribution (5 AM – 10 PM)")
+                    .font(.custom("Poppins-Regular", size: 12))
+                    .foregroundColor(.placeholderMuted)
+
+                HStack(alignment: .bottom, spacing: 3) {
+                    ForEach(5..<23, id: \.self) { hour in
+                        let count = data.hours[hour] ?? 0
+                        let isMorning = hour == data.morningPeak
+                        let isEvening = hour == data.eveningPeak
+                        VStack(spacing: 2) {
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(isMorning ? Color.orange :
+                                      isEvening ? Color.purple :
+                                      Color.primaryBrand.opacity(0.35))
+                                .frame(width: 14,
+                                       height: max(4, 60 * CGFloat(count) / CGFloat(maxCount)))
+                            Text("\(hour)")
+                                .font(.system(size: 8))
+                                .foregroundColor(.placeholderMuted)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(Color.surfaceCard)
+        .cornerRadius(16)
+        .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.borderLine, lineWidth: 1))
+    }
+
+    private func peakPill(label: String, hour: Int?, icon: String, color: Color) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .foregroundColor(color)
+                .font(.system(size: 20))
+            Text(hour.map { String(format: "%02d:00", $0) } ?? "--:--")
+                .font(.custom("Poppins-Bold", size: 16))
+                .foregroundColor(hour != nil ? .textPrimary : .placeholderMuted)
+            Text(label)
+                .font(.custom("Poppins-Regular", size: 11))
+                .foregroundColor(.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(12)
+        .background(color.opacity(0.08))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Offline banner
+
+    private var offlineBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "wifi.slash")
+                .font(.system(size: 13, weight: .semibold))
+            Text("Offline — showing last cached data")
+                .font(.custom("Poppins-Regular", size: 12))
+            Spacer()
+        }
+        .foregroundColor(Color(red: 0.6, green: 0.4, blue: 0))
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+        .background(Color(red: 1, green: 0.95, blue: 0.8))
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.system(size: 40))
+                .foregroundColor(.placeholderMuted)
+            Text("No analytics data yet")
+                .font(.custom("Poppins-SemiBold", size: 16))
+                .foregroundColor(.textPrimary)
+            Text("Data is collected as rides are completed.")
+                .font(.custom("Poppins-Regular", size: 13))
+                .foregroundColor(.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(40)
+    }
+
+    // MARK: - Helpers
+
+    private func timeAgo(_ date: Date) -> String {
+        let seconds = Int(Date().timeIntervalSince(date))
+        guard seconds >= 60 else { return "just now" }
+        return "\(seconds / 60) min ago"
+    }
+}

--- a/GN1Swift/Views/CreateRideView.swift
+++ b/GN1Swift/Views/CreateRideView.swift
@@ -5,6 +5,7 @@ struct CreateRideView: View {
     @StateObject private var viewModel: CreateRideViewModel
     @StateObject private var originSearch = LocationSearchService()
     @StateObject private var destinationSearch = LocationSearchService()
+    @StateObject private var favoritesVM = FavoritesViewModel()
     @Environment(\.dismiss) private var dismiss
     @State private var navigateToRequests = false
     private enum Field { case origin, destination }
@@ -19,10 +20,12 @@ struct CreateRideView: View {
             ScrollView {
                 VStack(spacing: 0) {
                     header
+                    favoritesSection
                     formFields
                 }
                 .padding(.vertical, 24)
             }
+            .onAppear { favoritesVM.load() }
             .background(Color.backgroundApp)
             .navigationBarHidden(true)
             .alert("Error", isPresented: Binding(
@@ -156,6 +159,21 @@ struct CreateRideView: View {
             }
             .inputStyle()
 
+            // Save as Favorite
+            Button {
+                favoritesVM.save(origin: viewModel.originText,
+                                 destination: viewModel.destinationText,
+                                 zone: viewModel.zone)
+            } label: {
+                Label("Save as Favorite", systemImage: "star")
+                    .font(.custom("Poppins-Medium", size: 13))
+                    .foregroundColor(viewModel.originText.isEmpty || viewModel.destinationText.isEmpty
+                                     ? .placeholderMuted : .primaryBrand)
+            }
+            .disabled(viewModel.originText.isEmpty || viewModel.destinationText.isEmpty)
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .padding(.top, -4)
+
             // Departure time
             VStack(alignment: .leading, spacing: 6) {
                 Text("Departure Time")
@@ -247,6 +265,61 @@ struct CreateRideView: View {
             .padding(.top, 8)
         }
         .padding(.horizontal, 24)
+    }
+
+    // MARK: - Saved Favorites
+
+    @ViewBuilder
+    private var favoritesSection: some View {
+        if !favoritesVM.favorites.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Saved Routes")
+                    .font(.custom("Poppins-SemiBold", size: 13))
+                    .foregroundColor(.textSecondary)
+                    .padding(.horizontal, 24)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 10) {
+                        ForEach(favoritesVM.favorites) { fav in
+                            favoriteChip(fav)
+                        }
+                    }
+                    .padding(.horizontal, 24)
+                }
+            }
+            .padding(.bottom, 16)
+        }
+    }
+
+    private func favoriteChip(_ fav: FavoriteRoute) -> some View {
+        HStack(spacing: 6) {
+            Button {
+                favoritesVM.apply(fav, to: viewModel)
+            } label: {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(fav.origin)
+                        .font(.custom("Poppins-SemiBold", size: 11))
+                        .foregroundColor(.textPrimary)
+                        .lineLimit(1)
+                    Text("→ \(fav.destination)")
+                        .font(.custom("Poppins-Regular", size: 10))
+                        .foregroundColor(.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+            Button {
+                favoritesVM.delete(id: fav.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.textSecondary)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background(Color.surfaceCard)
+        .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.primaryBrand.opacity(0.3), lineWidth: 1))
+        .cornerRadius(10)
     }
 
     // MARK: - Suggestions List

--- a/GN1Swift/Views/HomeView.swift
+++ b/GN1Swift/Views/HomeView.swift
@@ -13,6 +13,7 @@ struct HomeView: View {
     @State private var weatherCondition = ""
     @State private var commuteForecastText = ""
     @State private var didLoadWeather = false
+    @State private var showAnalytics = false
 
     var body: some View {
         NavigationStack {
@@ -46,6 +47,9 @@ struct HomeView: View {
 
                     statsStrip
 
+                    // ── Demand Analytics ───────────────────────────────────────
+                    demandAnalyticsCard
+
                     // ── Recent Rides ───────────────────────────────────────────
                     HStack {
                         Text("Recent Rides")
@@ -68,6 +72,7 @@ struct HomeView: View {
             .background(Color.backgroundApp)
             } // VStack
         }
+        .sheet(isPresented: $showAnalytics) { AnalyticsDashboardView() }
         .animation(.easeInOut(duration: 0.25), value: vm.isOffline)
         .task {
             vm.load()
@@ -294,6 +299,41 @@ struct HomeView: View {
         .background(Color.surfaceCard)
         .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.borderLine, lineWidth: 1))
         .cornerRadius(16)
+    }
+
+    // MARK: - Demand Analytics Card
+
+    private var demandAnalyticsCard: some View {
+        Button { showAnalytics = true } label: {
+            HStack(spacing: 14) {
+                Image(systemName: "chart.bar.fill")
+                    .font(.system(size: 22))
+                    .foregroundColor(.primaryBrand)
+                    .frame(width: 44, height: 44)
+                    .background(Color.primaryBrand.opacity(0.1))
+                    .cornerRadius(10)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Demand Analytics")
+                        .font(.custom("Poppins-SemiBold", size: 15))
+                        .foregroundColor(.textPrimary)
+                    Text("Top zones & peak hours")
+                        .font(.custom("Poppins-Regular", size: 12))
+                        .foregroundColor(.textSecondary)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(.placeholderMuted)
+            }
+            .padding(16)
+            .background(Color.surfaceCard)
+            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.borderLine, lineWidth: 1))
+            .cornerRadius(16)
+        }
+        .buttonStyle(PlainButtonStyle())
     }
 
     // MARK: - Weather (unchanged)

--- a/GN1Swift/Views/RideFilterSheet.swift
+++ b/GN1Swift/Views/RideFilterSheet.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct RideFilterSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let zones: [String]
+    @Binding var selectedZone: String
+    @Binding var minSeats: Int
+    @Binding var minRating: Double
+
+    private let ratingOptions: [(label: String, value: Double)] = [
+        ("All", 0.0), ("4.0+", 4.0), ("4.5+", 4.5)
+    ]
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 32) {
+                    zoneSection
+                    seatsSection
+                    ratingSection
+                }
+                .padding(20)
+            }
+            .background(Color.backgroundApp)
+            .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Reset") {
+                        selectedZone = "All"
+                        minSeats    = 1
+                        minRating   = 0.0
+                    }
+                    .font(.custom("Poppins-Medium", size: 15))
+                    .foregroundColor(.textSecondary)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .font(.custom("Poppins-SemiBold", size: 15))
+                        .foregroundColor(.primaryBrand)
+                }
+            }
+        }
+    }
+
+    // MARK: - Zone
+
+    private var zoneSection: some View {
+        filterBlock("Zone") {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 10) {
+                    ForEach(zones, id: \.self) { zone in
+                        let active = selectedZone == zone
+                        Button { selectedZone = zone } label: {
+                            HStack(spacing: 5) {
+                                if zone != "All" {
+                                    Image(systemName: "mappin.circle.fill")
+                                        .font(.system(size: 12))
+                                }
+                                Text(zone)
+                                    .font(.custom("Poppins-SemiBold", size: 13))
+                            }
+                            .foregroundColor(active ? .white : .textPrimary)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 9)
+                            .background(active ? Color.primaryBrand : Color.surfaceCard)
+                            .overlay(RoundedRectangle(cornerRadius: 20)
+                                .stroke(active ? Color.primaryBrand : Color.borderLine, lineWidth: 1))
+                            .cornerRadius(20)
+                        }
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
+    // MARK: - Seats
+
+    private var seatsSection: some View {
+        filterBlock("Minimum Seats") {
+            HStack {
+                Spacer()
+                Button {
+                    if minSeats > 1 { minSeats -= 1 }
+                } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(minSeats > 1 ? .primaryBrand : .placeholderMuted)
+                        .frame(width: 48, height: 48)
+                        .background(Color.surfaceCard)
+                        .overlay(RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color.borderLine, lineWidth: 1))
+                        .cornerRadius(14)
+                }
+                .disabled(minSeats <= 1)
+
+                VStack(spacing: 2) {
+                    Text("\(minSeats)")
+                        .font(.custom("Poppins-Bold", size: 48))
+                        .foregroundColor(.textPrimary)
+                    Text("or more")
+                        .font(.custom("Poppins-Regular", size: 12))
+                        .foregroundColor(.placeholderMuted)
+                }
+                .frame(width: 110)
+
+                Button {
+                    if minSeats < 8 { minSeats += 1 }
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundColor(minSeats < 8 ? .primaryBrand : .placeholderMuted)
+                        .frame(width: 48, height: 48)
+                        .background(Color.surfaceCard)
+                        .overlay(RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color.borderLine, lineWidth: 1))
+                        .cornerRadius(14)
+                }
+                .disabled(minSeats >= 8)
+                Spacer()
+            }
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - Rating
+
+    private var ratingSection: some View {
+        filterBlock("Minimum Rating") {
+            HStack(spacing: 12) {
+                ForEach(ratingOptions, id: \.label) { option in
+                    let active = minRating == option.value
+                    Button { minRating = option.value } label: {
+                        VStack(spacing: 6) {
+                            if option.value > 0 {
+                                HStack(spacing: 3) {
+                                    ForEach(0..<Int(option.value), id: \.self) { _ in
+                                        Image(systemName: "star.fill")
+                                            .font(.system(size: 11))
+                                            .foregroundColor(active ? .white : .yellow)
+                                    }
+                                }
+                            } else {
+                                Image(systemName: "line.3.horizontal.decrease")
+                                    .font(.system(size: 16))
+                                    .foregroundColor(active ? .white : .placeholderMuted)
+                            }
+                            Text(option.label)
+                                .font(.custom("Poppins-SemiBold", size: 13))
+                                .foregroundColor(active ? .white : .textPrimary)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(active ? Color.primaryBrand : Color.surfaceCard)
+                        .overlay(RoundedRectangle(cornerRadius: 14)
+                            .stroke(active ? Color.primaryBrand : Color.borderLine, lineWidth: 1))
+                        .cornerRadius(14)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Helper
+
+    private func filterBlock<Content: View>(_ title: String,
+                                            @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(title)
+                .font(.custom("Poppins-Bold", size: 17))
+                .foregroundColor(.textPrimary)
+            content()
+        }
+    }
+}

--- a/GN1Swift/Views/RidesView.swift
+++ b/GN1Swift/Views/RidesView.swift
@@ -19,6 +19,7 @@ struct RidesView: View {
     // Sheets / navigation
     @State private var showCreateRide = false
     @State private var showRecommendations = false
+    @State private var showSearch = false
     @State private var rideInProgress: Ride?
     @State private var navigateToRideInProgress = false
     @State private var selectedRide: Ride?
@@ -109,6 +110,9 @@ struct RidesView: View {
                 Text(driverVM.activeExpiredMessage ?? "")
             }
             // Sheets
+            .fullScreenCover(isPresented: $showSearch) {
+                SearchRidesView(rides: passengerVM.allRides)
+            }
             .sheet(isPresented: $showCreateRide) { CreateRideView() }
             .onChange(of: showCreateRide) { _, isShowing in
                 // Refresh pending rides immediately when the create sheet closes,
@@ -155,6 +159,16 @@ struct RidesView: View {
             }
 
             Spacer()
+
+            // Search — passenger only
+            if effectiveMode == .passenger {
+                Button { showSearch = true } label: {
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 18))
+                        .foregroundColor(.primaryBrand)
+                        .frame(width: 36, height: 36)
+                }
+            }
 
             // Recommendations shortcut — passenger only
             if effectiveMode == .passenger {

--- a/GN1Swift/Views/RidesView.swift
+++ b/GN1Swift/Views/RidesView.swift
@@ -20,6 +20,7 @@ struct RidesView: View {
     @State private var showCreateRide = false
     @State private var showRecommendations = false
     @State private var showSearch = false
+    @State private var showFilters = false
     @State private var rideInProgress: Ride?
     @State private var navigateToRideInProgress = false
     @State private var selectedRide: Ride?
@@ -112,6 +113,15 @@ struct RidesView: View {
             // Sheets
             .fullScreenCover(isPresented: $showSearch) {
                 SearchRidesView(rides: passengerVM.allRides)
+            }
+            .sheet(isPresented: $showFilters) {
+                RideFilterSheet(
+                    zones: passengerVM.zones,
+                    selectedZone: $passengerVM.selectedZone,
+                    minSeats: $passengerVM.minSeats,
+                    minRating: $passengerVM.minRating
+                )
+                .presentationDetents([.medium, .large])
             }
             .sheet(isPresented: $showCreateRide) { CreateRideView() }
             .onChange(of: showCreateRide) { _, isShowing in
@@ -219,8 +229,8 @@ struct RidesView: View {
 
     @ViewBuilder
     private var passengerContent: some View {
-        // --- Filters ---
-        filtersSection
+        // --- Filter bar ---
+        filterBar
             .padding(.top, 8)
 
         // --- Available Rides ---
@@ -305,72 +315,75 @@ struct RidesView: View {
         DriverRequestsSectionView(viewModel: driverVM)
     }
 
-    // MARK: - Filters Section
+    // MARK: - Filter Bar
 
-    private var filtersSection: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            filterRow(label: "Zone") {
-                ForEach(passengerVM.zones, id: \.self) { zone in
-                    let isActive = passengerVM.selectedZone == zone
-                    filterChip(title: zone, isActive: isActive) {
-                        passengerVM.selectedZone = zone
-                    }
-                }
-            }
-            filterRow(label: "Seats") {
-                ForEach([1, 2, 3, 4], id: \.self) { n in
-                    let isActive = passengerVM.minSeats == n
-                    filterChip(title: "\(n)+", isActive: isActive) {
-                        passengerVM.minSeats = n
-                    }
-                }
-            }
-            filterRow(label: "Rating") {
-                ForEach(ratingFilters, id: \.label) { filter in
-                    let isActive = passengerVM.minRating == filter.value
-                    filterChip(title: filter.label, isActive: isActive) {
-                        passengerVM.minRating = filter.value
-                    }
-                }
-            }
-        }
-        .padding(.top, 4)
+    private var hasActiveFilters: Bool {
+        passengerVM.selectedZone != "All" || passengerVM.minSeats > 1 || passengerVM.minRating > 0
     }
 
-    private func filterRow<Content: View>(label: String,
-                                          @ViewBuilder chips: () -> Content) -> some View {
+    private var filterBar: some View {
         HStack(spacing: 0) {
-            Text(label)
-                .font(.custom("Poppins-SemiBold", size: 11))
-                .foregroundColor(.placeholderMuted)
-                .frame(width: 46, alignment: .leading)
-                .padding(.leading, 16)
-
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
-                    chips()
+                    if !hasActiveFilters {
+                        Text("All rides")
+                            .font(.custom("Poppins-Regular", size: 13))
+                            .foregroundColor(.placeholderMuted)
+                    } else {
+                        if passengerVM.selectedZone != "All" {
+                            activeChip(passengerVM.selectedZone) {
+                                passengerVM.selectedZone = "All"
+                            }
+                        }
+                        if passengerVM.minSeats > 1 {
+                            activeChip("\(passengerVM.minSeats)+ seats") {
+                                passengerVM.minSeats = 1
+                            }
+                        }
+                        if passengerVM.minRating > 0 {
+                            activeChip(String(format: "%.1f★", passengerVM.minRating)) {
+                                passengerVM.minRating = 0
+                            }
+                        }
+                    }
                 }
-                .padding(.horizontal, 8)
+                .padding(.leading, 16)
                 .padding(.vertical, 4)
             }
+
+            Button { showFilters = true } label: {
+                Image(systemName: "slider.horizontal.3")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundColor(hasActiveFilters ? .white : .primaryBrand)
+                    .frame(width: 38, height: 38)
+                    .background(hasActiveFilters ? Color.primaryBrand : Color.surfaceCard)
+                    .overlay(RoundedRectangle(cornerRadius: 10)
+                        .stroke(hasActiveFilters ? Color.clear : Color.borderLine, lineWidth: 1))
+                    .cornerRadius(10)
+            }
+            .padding(.trailing, 16)
+            .padding(.leading, 8)
         }
-        .frame(height: 36)
+        .frame(height: 50)
     }
 
-    private func filterChip(title: String, isActive: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
+    private func activeChip(_ text: String, onRemove: @escaping () -> Void) -> some View {
+        HStack(spacing: 5) {
+            Text(text)
                 .font(.custom("Poppins-SemiBold", size: 12))
-                .foregroundColor(isActive ? .white : .textPrimary)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(isActive ? Color.primaryBrand : Color.surfaceCard)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(isActive ? Color.primaryBrand : Color.borderLine, lineWidth: 1)
-                )
-                .cornerRadius(20)
+                .foregroundColor(.primaryBrand)
+            Button(action: onRemove) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundColor(.primaryBrand)
+            }
         }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.primaryBrand.opacity(0.1))
+        .overlay(RoundedRectangle(cornerRadius: 20)
+            .stroke(Color.primaryBrand.opacity(0.35), lineWidth: 1))
+        .cornerRadius(20)
     }
 
     // MARK: - Ride Card (Passenger marketplace)

--- a/GN1Swift/Views/RidesView.swift
+++ b/GN1Swift/Views/RidesView.swift
@@ -219,13 +219,9 @@ struct RidesView: View {
 
     @ViewBuilder
     private var passengerContent: some View {
-        // --- Filter card ---
-        filterCard
-            .padding(.horizontal, 16)
+        // --- Filters ---
+        filtersSection
             .padding(.top, 8)
-
-        ratingChipsRow
-            .padding(.top, 12)
 
         // --- Available Rides ---
         sectionLabel("ALL AVAILABLE RIDES", color: .placeholderMuted)
@@ -309,89 +305,72 @@ struct RidesView: View {
         DriverRequestsSectionView(viewModel: driverVM)
     }
 
-    // MARK: - Filter Card (Passenger)
+    // MARK: - Filters Section
 
-    private var filterCard: some View {
-        VStack(spacing: 12) {
-            Menu {
+    private var filtersSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            filterRow(label: "Zone") {
                 ForEach(passengerVM.zones, id: \.self) { zone in
-                    Button(zone) { passengerVM.selectedZone = zone }
-                }
-            } label: {
-                HStack {
-                    Text("Zone:")
-                        .font(.custom("Poppins-Regular", size: 13))
-                        .foregroundColor(.placeholderMuted)
-                    Text(passengerVM.selectedZone)
-                        .font(.custom("Poppins-SemiBold", size: 13))
-                        .foregroundColor(.textPrimary)
-                    Spacer()
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12))
-                        .foregroundColor(.placeholderMuted)
-                }
-                .padding()
-                .background(Color.surfaceCard)
-                .cornerRadius(10)
-            }
-
-            HStack(spacing: 12) {
-                HStack(spacing: 6) {
-                    Image(systemName: "person.2")
-                        .foregroundColor(.placeholderMuted)
-                        .font(.system(size: 13))
-                    Text("Min seats:")
-                        .font(.custom("Poppins-Regular", size: 12))
-                        .foregroundColor(.placeholderMuted)
-                    Text("\(passengerVM.minSeats)")
-                        .font(.custom("Poppins-SemiBold", size: 13))
-                        .foregroundColor(.textPrimary)
-                        .frame(minWidth: 16)
-                    Stepper("", value: $passengerVM.minSeats, in: 1...8)
-                        .labelsHidden()
-                }
-                Spacer()
-                Button { passengerVM.applyFilters() } label: {
-                    Text("Search")
-                        .font(.custom("Poppins-SemiBold", size: 13))
-                        .foregroundColor(.white)
-                        .frame(width: 80, height: 36)
-                        .background(Color.primaryBrand)
-                        .cornerRadius(8)
-                }
-            }
-        }
-        .padding(16)
-        .background(Color.surfaceCard)
-        .cornerRadius(12)
-    }
-
-    // MARK: - Rating Chips
-
-    private var ratingChipsRow: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(ratingFilters, id: \.label) { filter in
-                    let isActive = passengerVM.minRating == filter.value
-                    Button { passengerVM.minRating = filter.value } label: {
-                        Text(filter.label)
-                            .font(.custom("Poppins-SemiBold", size: 13))
-                            .foregroundColor(isActive ? .white : .textPrimary)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(isActive ? Color.primaryBrand : Color.backgroundApp)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 20)
-                                    .stroke(isActive ? Color.primaryBrand : Color.borderLine, lineWidth: 1)
-                            )
-                            .cornerRadius(20)
+                    let isActive = passengerVM.selectedZone == zone
+                    filterChip(title: zone, isActive: isActive) {
+                        passengerVM.selectedZone = zone
                     }
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 4)
+            filterRow(label: "Seats") {
+                ForEach([1, 2, 3, 4], id: \.self) { n in
+                    let isActive = passengerVM.minSeats == n
+                    filterChip(title: "\(n)+", isActive: isActive) {
+                        passengerVM.minSeats = n
+                    }
+                }
+            }
+            filterRow(label: "Rating") {
+                ForEach(ratingFilters, id: \.label) { filter in
+                    let isActive = passengerVM.minRating == filter.value
+                    filterChip(title: filter.label, isActive: isActive) {
+                        passengerVM.minRating = filter.value
+                    }
+                }
+            }
         }
-        .frame(height: 44)
+        .padding(.top, 4)
+    }
+
+    private func filterRow<Content: View>(label: String,
+                                          @ViewBuilder chips: () -> Content) -> some View {
+        HStack(spacing: 0) {
+            Text(label)
+                .font(.custom("Poppins-SemiBold", size: 11))
+                .foregroundColor(.placeholderMuted)
+                .frame(width: 46, alignment: .leading)
+                .padding(.leading, 16)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    chips()
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+            }
+        }
+        .frame(height: 36)
+    }
+
+    private func filterChip(title: String, isActive: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(.custom("Poppins-SemiBold", size: 12))
+                .foregroundColor(isActive ? .white : .textPrimary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isActive ? Color.primaryBrand : Color.surfaceCard)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(isActive ? Color.primaryBrand : Color.borderLine, lineWidth: 1)
+                )
+                .cornerRadius(20)
+        }
     }
 
     // MARK: - Ride Card (Passenger marketplace)

--- a/GN1Swift/Views/SearchRidesView.swift
+++ b/GN1Swift/Views/SearchRidesView.swift
@@ -134,7 +134,7 @@ struct SearchRidesView: View {
             Image(systemName: "magnifyingglass")
                 .font(.system(size: 38))
                 .foregroundColor(.placeholderMuted)
-            Text(vm.query.isEmpty ? "Start typing to search" : "No rides match "\(vm.query)"")
+            Text(vm.query.isEmpty ? "Start typing to search" : "No rides match \"\(vm.query)\"")
                 .font(.custom("Poppins-SemiBold", size: 15))
                 .foregroundColor(.textPrimary)
                 .multilineTextAlignment(.center)

--- a/GN1Swift/Views/SearchRidesView.swift
+++ b/GN1Swift/Views/SearchRidesView.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+
+struct SearchRidesView: View {
+    let rides: [Ride]
+    @StateObject private var vm: SearchRidesViewModel
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var isSearchFocused: Bool
+
+    init(rides: [Ride]) {
+        self.rides = rides
+        _vm = StateObject(wrappedValue: SearchRidesViewModel(rides: rides))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.backgroundApp.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    topBar
+
+                    if vm.isFiltering {
+                        Spacer()
+                        ProgressView("Searching…")
+                            .font(.custom("Poppins-Regular", size: 14))
+                        Spacer()
+                    } else if vm.results.isEmpty {
+                        emptyState
+                    } else {
+                        resultsList
+                    }
+                }
+            }
+            .safeAreaInset(edge: .bottom) { searchBar }
+            .onAppear { isSearchFocused = true }
+        }
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Text("Search Rides")
+                .font(.custom("Poppins-Bold", size: 22))
+                .foregroundColor(.textPrimary)
+            Spacer()
+            Button("Cancel") { dismiss() }
+                .font(.custom("Poppins-Medium", size: 15))
+                .foregroundColor(.primaryBrand)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - Results list
+
+    private var resultsList: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                Text("\(vm.results.count) ride\(vm.results.count == 1 ? "" : "s") found")
+                    .font(.custom("Poppins-Regular", size: 12))
+                    .foregroundColor(.placeholderMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 4)
+
+                ForEach(vm.results) { ride in
+                    NavigationLink(destination: RideDetailView(ride: ride)) {
+                        searchResultCard(ride: ride)
+                    }
+                    .buttonStyle(PlainButtonStyle())
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 12)
+        }
+    }
+
+    // MARK: - Result card
+
+    private func searchResultCard(ride: Ride) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(spacing: 6) {
+                Circle()
+                    .fill(Color.primaryBrand)
+                    .frame(width: 8, height: 8)
+                    .padding(.top, 4)
+                Rectangle()
+                    .fill(Color.borderLine)
+                    .frame(width: 1)
+                    .frame(maxHeight: .infinity)
+                Circle()
+                    .fill(Color.green)
+                    .frame(width: 8, height: 8)
+                    .padding(.bottom, 4)
+            }
+            .frame(width: 8)
+
+            VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(ride.origin)
+                        .font(.custom("Poppins-SemiBold", size: 13))
+                        .foregroundColor(.textPrimary)
+                    Text(ride.destination)
+                        .font(.custom("Poppins-Regular", size: 13))
+                        .foregroundColor(.textSecondary)
+                }
+
+                HStack(spacing: 10) {
+                    Label(ride.driverName, systemImage: "person.fill")
+                        .font(.custom("Poppins-Regular", size: 11))
+                        .foregroundColor(.textSecondary)
+                    Label(ride.zone, systemImage: "mappin")
+                        .font(.custom("Poppins-Regular", size: 11))
+                        .foregroundColor(.textSecondary)
+                    Spacer()
+                    Text(String(format: "$%.0f", ride.price))
+                        .font(.custom("Poppins-SemiBold", size: 13))
+                        .foregroundColor(.primaryBrand)
+                }
+            }
+        }
+        .padding(14)
+        .background(Color.surfaceCard)
+        .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.borderLine, lineWidth: 1))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Spacer()
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 38))
+                .foregroundColor(.placeholderMuted)
+            Text(vm.query.isEmpty ? "Start typing to search" : "No rides match "\(vm.query)"")
+                .font(.custom("Poppins-SemiBold", size: 15))
+                .foregroundColor(.textPrimary)
+                .multilineTextAlignment(.center)
+            if !vm.query.isEmpty {
+                Text("Try searching by origin, destination, zone or driver name.")
+                    .font(.custom("Poppins-Regular", size: 13))
+                    .foregroundColor(.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+    }
+
+    // MARK: - Search bar (pinned to bottom)
+
+    private var searchBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.placeholderMuted)
+                    .font(.system(size: 15))
+                TextField("Origin, destination, zone or driver…", text: $vm.query)
+                    .font(.custom("Poppins-Regular", size: 15))
+                    .foregroundColor(.textPrimary)
+                    .focused($isSearchFocused)
+                    .autocorrectionDisabled()
+                if !vm.query.isEmpty {
+                    Button { vm.query = "" } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.placeholderMuted)
+                            .font(.system(size: 16))
+                    }
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(Color.surfaceCard)
+            .overlay(RoundedRectangle(cornerRadius: 12).stroke(Color.borderLine, lineWidth: 1))
+            .cornerRadius(12)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+        }
+        .background(Color.backgroundApp)
+    }
+}

--- a/GN1Swift/Views/TabViewmain.swift
+++ b/GN1Swift/Views/TabViewmain.swift
@@ -33,12 +33,19 @@ struct TabViewmain: View {
                     }
                     .tag(2)
 
+                AnalyticsDashboardView()
+                    .tabItem {
+                        Image(systemName: "chart.bar.fill")
+                        Text("Analytics")
+                    }
+                    .tag(3)
+
                 ProfileView(isLoggedIn: $isLoggedIn)
                     .tabItem {
                         Image(systemName: "person.fill")
                         Text("Profile")
                     }
-                    .tag(3)
+                    .tag(4)
             }
             .tint(.primaryBrand)
 

--- a/GN1Swift/Views/TabViewmain.swift
+++ b/GN1Swift/Views/TabViewmain.swift
@@ -33,19 +33,12 @@ struct TabViewmain: View {
                     }
                     .tag(2)
 
-                AnalyticsDashboardView()
-                    .tabItem {
-                        Image(systemName: "chart.bar.fill")
-                        Text("Analytics")
-                    }
-                    .tag(3)
-
                 ProfileView(isLoggedIn: $isLoggedIn)
                     .tabItem {
                         Image(systemName: "person.fill")
                         Text("Profile")
                     }
-                    .tag(4)
+                    .tag(3)
             }
             .tint(.primaryBrand)
 


### PR DESCRIPTION
# Sprint 4 — Caching · Local Storage · Multi-threading
  
  **Resumen**

  Implementación de las tres features técnicas del Sprint 4 más mejoras de UX en la vista de rides.

  ---
  Features

  Caching — Analytics Dashboard
  - AnalyticsCacheService: dos instancias de NSCache con TTL de 300 s para zonas y horas pico. Si el caché es válido, la vista se sirve sin ninguna llamada a red.
  - AnalyticsDashboardViewModel: en cache miss dispara async let concurrente para zonas y horas pico usando withCheckedContinuation para bridgear las APIs de callback.
  - AnalyticsDashboardView: barras de demanda por zona, pills de horario pico (mañana/tarde), chip de estado de caché, banner offline, botón de refresh manual.
  - Movido del tab bar a una card en HomeView (sheet) — más natural como info contextual para drivers y pasajeros.
  
  Local Storage — Favorite Routes
  - FavoritePersistenceController: stack de CoreData independiente (FavoritesModel) construido en código, sin .xcdatamodeld, siguiendo el patrón de ProfilePersistenceController. Evita migraciones en el store existente de rides.
  - FavoriteRouteLocalDataSource: CRUD en background context. Rutas duplicadas (mismo origin + destination) se fusionan incrementando useCount en lugar de insertar un registro nuevo. Resultados ordenados por useCount desc.
  - FavoritesViewModel: carga, guarda, elimina y aplica favoritos al formulario de creación. 
  - CreateRideView: scroll horizontal de chips de rutas guardadas sobre el formulario; tapping pre-llena origin/destination/zone; botón "Save as Favorite" bajo el campo de zona.

  Multi-threading — Ride Search
  - SearchRidesViewModel: pipeline de Combine — debounce(300 ms) + removeDuplicates() + filtrado en DispatchQueue.global(qos: .userInitiated), resultados publicados de vuelta en main thread.
  - SearchRidesView: overlay fullScreenCover con barra de búsqueda fija al fondo via safeAreaInset, resultados en LazyVStack con NavigationLink a RideDetailView. Teclado auto-enfocado al abrir.
  - Accesible desde el ícono de lupa en el app bar de RidesView (modo pasajero). 

  Mejoras de UX

  - Filtros de rides reemplazados por una filter bar compacta: muestra los filtros activos como pills dismissibles y un botón de sliders que abre RideFilterSheet (detent medio/grande) con zona en pills, asientos en contador +/−, y rating en
  cards con estrellas.

  Bug fixes

  - Comillas tipográficas reemplazadas por ASCII escapadas en el empty state de SearchRidesView.
  - import Combine agregado a AnalyticsDashboardViewModel y FavoritesViewModel.