### PR TITLE
fix(gamification): micro-optimizations for Community screen rendering

### DIFF
--- a/GN1Swift/Components/BadgeView.swift
+++ b/GN1Swift/Components/BadgeView.swift
@@ -39,7 +39,8 @@ struct BadgeView: View {
                     }
                 }
             }
-            
+            .drawingGroup()
+
             Text(badge.name)
                 .font(.custom("Poppins-SemiBold", size: 12))
                 .foregroundColor(.textPrimary)

--- a/GN1Swift/Components/BadgeView.swift
+++ b/GN1Swift/Components/BadgeView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct BadgeView: View {
+struct BadgeView: View, Equatable {
     let badge: Badge
     let size: CGFloat = 80
     

--- a/GN1Swift/Components/LeaderboardRowView.swift
+++ b/GN1Swift/Components/LeaderboardRowView.swift
@@ -50,7 +50,7 @@ struct LeaderboardRowView: View {
         .cornerRadius(12)
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(isCurrentUser ? Color.primaryBrand : Color.clear, lineWidth: 1)
+                .stroke(Color.primaryBrand, lineWidth: isCurrentUser ? 1 : 0)
         )
     }
 }

--- a/GN1Swift/Components/LeaderboardRowView.swift
+++ b/GN1Swift/Components/LeaderboardRowView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct LeaderboardRowView: View {
+struct LeaderboardRowView: View, Equatable {
     let rank: Int
     let player: UserGamification
     let isCurrentUser: Bool

--- a/GN1Swift/Model/UserGamification.swift
+++ b/GN1Swift/Model/UserGamification.swift
@@ -1,7 +1,7 @@
 import Foundation
 import FirebaseFirestore
 
-struct Badge: Identifiable, Codable {
+struct Badge: Identifiable, Codable, Equatable {
     let id: String
     let name: String
     let description: String
@@ -47,7 +47,7 @@ struct Badge: Identifiable, Codable {
     }
 }
 
-struct StreakInfo: Codable {
+struct StreakInfo: Codable, Equatable {
     var currentStreak: Int = 0
     var longestStreak: Int = 0
     var lastActivityDate: Date?
@@ -59,7 +59,7 @@ struct StreakInfo: Codable {
     }
 }
 
-struct UserGamification: Codable {
+struct UserGamification: Codable, Equatable {
     let userId: String
     var displayName: String = ""
     var points: Int = 0

--- a/GN1Swift/Model/UserGamification.swift
+++ b/GN1Swift/Model/UserGamification.swift
@@ -142,7 +142,7 @@ struct UserGamification: Codable, Equatable {
         self.points = dict["points"] as? Int ?? 0
         self.level = dict["level"] as? Int ?? 1
         self.totalXP = dict["totalXP"] as? Int ?? 0
-        self.lastGamificationUpdate = Self.parseDate(dict["lastGamificationUpdate"]) ?? Date()
+        self.lastGamificationUpdate = Self.parseDate(dict["lastGamificationUpdate"]) ?? Date(timeIntervalSince1970: 0)
         
         // Parse badges
         if let badgesData = dict["badges"] as? [[String: Any]] {

--- a/GN1Swift/Views/CommunityView.swift
+++ b/GN1Swift/Views/CommunityView.swift
@@ -156,6 +156,7 @@ struct CommunityView: View {
                                 player: player,
                                 isCurrentUser: isCurrentUser
                             )
+                            .equatable()
                         }
                         .padding(.horizontal, 24)
                     }

--- a/GN1Swift/Views/CommunityView.swift
+++ b/GN1Swift/Views/CommunityView.swift
@@ -148,17 +148,19 @@ struct CommunityView: View {
                     .frame(maxWidth: .infinity)
                     .padding(24)
                 } else {
-                    ForEach(Array(viewModel.topPlayers.enumerated()), id: \.element.userId) { index, player in
-                        let isCurrentUser = Auth.auth().currentUser?.uid == player.userId
-                        LeaderboardRowView(
-                            rank: index + 1,
-                            player: player,
-                            isCurrentUser: isCurrentUser
-                        )
+                    LazyVStack(spacing: 16) {
+                        ForEach(Array(viewModel.topPlayers.enumerated()), id: \.element.userId) { index, player in
+                            let isCurrentUser = Auth.auth().currentUser?.uid == player.userId
+                            LeaderboardRowView(
+                                rank: index + 1,
+                                player: player,
+                                isCurrentUser: isCurrentUser
+                            )
+                        }
+                        .padding(.horizontal, 24)
                     }
-                    .padding(.horizontal, 24)
                 }
-                
+
                 Spacer()
                     .frame(height: 20)
             }

--- a/GN1Swift/Views/CommunityView.swift
+++ b/GN1Swift/Views/CommunityView.swift
@@ -39,7 +39,7 @@ struct CommunityView: View {
                     .padding(.horizontal, 24)
                     .padding(.bottom, 16)
                     
-                    if viewModel.isLoading {
+                    if viewModel.isLoading && viewModel.gamification == nil && viewModel.topPlayers.isEmpty {
                         Spacer()
                         ProgressView()
                         Spacer()
@@ -101,6 +101,7 @@ struct CommunityView: View {
                             LazyVGrid(columns: [GridItem(.adaptive(minimum: 100))], spacing: 12) {
                                 ForEach(gamification.badges) { badge in
                                     BadgeView(badge: badge)
+                                        .equatable()
                                 }
                             }
                             .padding(.horizontal, 4)


### PR DESCRIPTION
The following points are the summary for the present pull request:

- LazyVStack: replace VStack with LazyVStack in leaderboard list to defer view instantiation to visible rows only.

-  Avoid Overdraw: replace Color.clear stroke (lineWidth: 1) with lineWidth: 0 in LeaderboardRowView to eliminate unnecessary GPU draw calls.

- drawingGroup(): pre-composite BadgeView's transparent ZStack layers into a single texture before sending to GPU.

- isLoading guard: only show spinner on initial load (no data) to keep views in the hierarchy on subsequent refreshes so Equatable diffing can take effect.

- Stable date fallback: fix lastGamificationUpdate default from Date() to Date(timeIntervalSince1970: 0) to ensure consistent equality checks across fetches.

- Equatable views: add Equatable conformance to LeaderboardRowView and BadgeView with .equatable() at call sites to skip body re-evaluation when data hasn't changed.
