### PR TITLE
feat(report-user): add incident reporting from user profiles

### DIFF
--- a/GN1Swift/Model/IncidentReport.swift
+++ b/GN1Swift/Model/IncidentReport.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum ReportCategory: String, CaseIterable, Identifiable {
+    case behavior   = "behavior"
+    case harassment = "harassment"
+    case fakeInfo   = "fake_info"
+    case vehicle    = "vehicle"
+    case other      = "other"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .behavior:   return "Comportamiento inapropiado"
+        case .harassment: return "Acoso"
+        case .fakeInfo:   return "Información falsa"
+        case .vehicle:    return "Vehículo en mal estado"
+        case .other:      return "Otro"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .behavior:   return "hand.raised.slash"
+        case .harassment: return "exclamationmark.bubble"
+        case .fakeInfo:   return "doc.badge.ellipsis"
+        case .vehicle:    return "car.fill"
+        case .other:      return "ellipsis.circle"
+        }
+    }
+}
+
+struct IncidentReport {
+    let reportedUserId: String
+    let reportedUserName: String
+    let category: ReportCategory
+    let description: String
+}

--- a/GN1Swift/Model/IncidentReport.swift
+++ b/GN1Swift/Model/IncidentReport.swift
@@ -11,11 +11,11 @@ enum ReportCategory: String, CaseIterable, Identifiable {
 
     var displayName: String {
         switch self {
-        case .behavior:   return "Comportamiento inapropiado"
-        case .harassment: return "Acoso"
-        case .fakeInfo:   return "Información falsa"
-        case .vehicle:    return "Vehículo en mal estado"
-        case .other:      return "Otro"
+        case .behavior:   return "Inappropriate behavior"
+        case .harassment: return "Harassment"
+        case .fakeInfo:   return "False information"
+        case .vehicle:    return "Poor vehicle condition"
+        case .other:      return "Other"
         }
     }
 
@@ -35,4 +35,9 @@ struct IncidentReport {
     let reportedUserName: String
     let category: ReportCategory
     let description: String
+}
+
+enum ReportSource {
+    case leaderboard
+    case rideDetail
 }

--- a/GN1Swift/Services/AppFacade.swift
+++ b/GN1Swift/Services/AppFacade.swift
@@ -254,6 +254,10 @@ final class AppFacade: AppFacadeType {
         }
     }  
   
+    func reportUser(report: IncidentReport, completion: @escaping (Bool) -> Void) {
+        cloudFunctionsService.reportUser(report: report, completion: completion)
+    }
+
     func fetchGamificationProfile(userId: String, completion: @escaping (UserGamification?) -> Void) {
         cloudFunctionsService.fetchGamificationProfile(userId: userId, completion: completion)
     }

--- a/GN1Swift/Services/AppFacadeType.swift
+++ b/GN1Swift/Services/AppFacadeType.swift
@@ -70,6 +70,7 @@ protocol AppFacadeType {
         seats: Int?,
         completion: @escaping (AuthFlowResult) -> Void
     )
+    func reportUser(report: IncidentReport, completion: @escaping (Bool) -> Void)
     func fetchGamificationProfile(userId: String, completion: @escaping (UserGamification?) -> Void)
     func fetchLeaderboard(completion: @escaping ([UserGamification]) -> Void)
     func submitRideRating(

--- a/GN1Swift/Services/CloudFuntionsService.swift
+++ b/GN1Swift/Services/CloudFuntionsService.swift
@@ -256,6 +256,21 @@ final class CloudFunctionsService {
         }
     }
     
+    // MARK: - Reports
+
+    func reportUser(report: IncidentReport, completion: @escaping (Bool) -> Void) {
+        let payload: [String: Any] = [
+            "reportedUserId": report.reportedUserId,
+            "reportedUserName": report.reportedUserName,
+            "category": report.category.rawValue,
+            "description": report.description
+        ]
+        functions.httpsCallable("reportUser").call(payload) { _, error in
+            if let error = error { print("reportUser error:", error.localizedDescription) }
+            completion(error == nil)
+        }
+    }
+
     // MARK: - Gamification
     
     func fetchGamificationProfile(userId: String, completion: @escaping (UserGamification?) -> Void) {

--- a/GN1Swift/ViewModels/ReportViewModel.swift
+++ b/GN1Swift/ViewModels/ReportViewModel.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+enum ReportSubmissionState: Equatable {
+    case idle
+    case loading
+    case success
+    case failure(String)
+}
+
+@MainActor
+final class ReportViewModel: ObservableObject {
+    @Published var category: ReportCategory = .behavior
+    @Published var description: String = ""
+    @Published var state: ReportSubmissionState = .idle
+
+    private let pendingReportKey = "uniride_pending_report"
+
+    func submit(reportedUserId: String, reportedUserName: String) {
+        let trimmed = description.trimmingCharacters(in: .whitespaces)
+        guard trimmed.count >= 10 else {
+            state = .failure("La descripción debe tener al menos 10 caracteres.")
+            return
+        }
+
+        state = .loading
+        let report = IncidentReport(
+            reportedUserId: reportedUserId,
+            reportedUserName: reportedUserName,
+            category: category,
+            description: trimmed
+        )
+
+        Task {
+            let success = await sendReport(report)
+            if success {
+                clearPendingReport()
+                state = .success
+            } else {
+                savePendingReport(report)
+                state = .failure("Sin conexión. El reporte se guardó y se enviará al reconectar.")
+            }
+        }
+    }
+
+    func retryPendingReportIfNeeded() {
+        guard let report = loadPendingReport() else { return }
+        Task {
+            let success = await sendReport(report)
+            if success { clearPendingReport() }
+        }
+    }
+
+    // MARK: - Private
+
+    private func sendReport(_ report: IncidentReport) async -> Bool {
+        await withCheckedContinuation { continuation in
+            CloudFunctionsService.shared.reportUser(report: report) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    private func savePendingReport(_ report: IncidentReport) {
+        let data: [String: String] = [
+            "reportedUserId": report.reportedUserId,
+            "reportedUserName": report.reportedUserName,
+            "category": report.category.rawValue,
+            "description": report.description
+        ]
+        UserDefaults.standard.set(data, forKey: pendingReportKey)
+    }
+
+    private func loadPendingReport() -> IncidentReport? {
+        guard
+            let data = UserDefaults.standard.dictionary(forKey: pendingReportKey) as? [String: String],
+            let userId = data["reportedUserId"],
+            let userName = data["reportedUserName"],
+            let categoryRaw = data["category"],
+            let category = ReportCategory(rawValue: categoryRaw),
+            let desc = data["description"]
+        else { return nil }
+
+        return IncidentReport(
+            reportedUserId: userId,
+            reportedUserName: userName,
+            category: category,
+            description: desc
+        )
+    }
+
+    private func clearPendingReport() {
+        UserDefaults.standard.removeObject(forKey: pendingReportKey)
+    }
+}

--- a/GN1Swift/ViewModels/ReportViewModel.swift
+++ b/GN1Swift/ViewModels/ReportViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 enum ReportSubmissionState: Equatable {
     case idle

--- a/GN1Swift/ViewModels/ReportViewModel.swift
+++ b/GN1Swift/ViewModels/ReportViewModel.swift
@@ -18,7 +18,7 @@ final class ReportViewModel: ObservableObject {
     func submit(reportedUserId: String, reportedUserName: String) {
         let trimmed = description.trimmingCharacters(in: .whitespaces)
         guard trimmed.count >= 10 else {
-            state = .failure("La descripción debe tener al menos 10 caracteres.")
+            state = .failure("Description must be at least 10 characters.")
             return
         }
 
@@ -37,7 +37,7 @@ final class ReportViewModel: ObservableObject {
                 state = .success
             } else {
                 savePendingReport(report)
-                state = .failure("Sin conexión. El reporte se guardó y se enviará al reconectar.")
+                state = .failure("No connection. Your report was saved and will be sent when you reconnect.")
             }
         }
     }

--- a/GN1Swift/Views/CommunityView.swift
+++ b/GN1Swift/Views/CommunityView.swift
@@ -150,11 +150,14 @@ struct CommunityView: View {
                 } else {
                     ForEach(Array(viewModel.topPlayers.enumerated()), id: \.element.userId) { index, player in
                         let isCurrentUser = Auth.auth().currentUser?.uid == player.userId
-                        LeaderboardRowView(
-                            rank: index + 1,
-                            player: player,
-                            isCurrentUser: isCurrentUser
-                        )
+                        NavigationLink(destination: UserProfileView(player: player)) {
+                            LeaderboardRowView(
+                                rank: index + 1,
+                                player: player,
+                                isCurrentUser: isCurrentUser
+                            )
+                        }
+                        .buttonStyle(.plain)
                     }
                     .padding(.horizontal, 24)
                 }

--- a/GN1Swift/Views/ReportUserView.swift
+++ b/GN1Swift/Views/ReportUserView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ReportUserView: View {
     let reportedUserId: String
     let reportedUserName: String
+    let source: ReportSource
 
     @StateObject private var viewModel = ReportViewModel()
     @Environment(\.dismiss) private var dismiss
@@ -12,53 +13,101 @@ struct ReportUserView: View {
             || viewModel.state == .loading
     }
 
+    private var isSuccess: Bool {
+        if case .success = viewModel.state { return true }
+        return false
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Color.backgroundApp.ignoresSafeArea()
 
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 24) {
-                        Text("Tu reporte será revisado por el equipo de UniRide. Provee información precisa para que podamos actuar.")
-                            .font(.custom("Poppins-Regular", size: 13))
-                            .foregroundColor(.textSecondary)
-                            .padding(.horizontal, 24)
-
-                        categorySection
-                        descriptionSection
-
-                        if case .failure(let msg) = viewModel.state {
-                            Text(msg)
-                                .font(.custom("Poppins-Regular", size: 12))
-                                .foregroundColor(.red)
+                if isSuccess {
+                    successView
+                } else {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 24) {
+                            Text("Your report will be reviewed by the UniRide team. Please provide accurate information so we can take action.")
+                                .font(.custom("Poppins-Regular", size: 13))
+                                .foregroundColor(.textSecondary)
                                 .padding(.horizontal, 24)
-                        }
 
-                        submitButton
+                            categorySection
+                            descriptionSection
+
+                            if case .failure(let msg) = viewModel.state {
+                                Text(msg)
+                                    .font(.custom("Poppins-Regular", size: 12))
+                                    .foregroundColor(.red)
+                                    .padding(.horizontal, 24)
+                            }
+
+                            submitButton
+                        }
+                        .padding(.vertical, 16)
                     }
-                    .padding(.vertical, 16)
                 }
             }
-            .navigationTitle("Reportar a \(reportedUserName)")
+            .navigationTitle(isSuccess ? "Report submitted" : "Report user")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancelar") { dismiss() }
-                        .font(.custom("Poppins-Regular", size: 14))
-                        .foregroundColor(.primaryBrand)
+                if !isSuccess {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel") { dismiss() }
+                            .font(.custom("Poppins-Regular", size: 14))
+                            .foregroundColor(.primaryBrand)
+                    }
                 }
-            }
-            .onChange(of: viewModel.state) { _, newState in
-                if case .success = newState { dismiss() }
             }
         }
     }
 
     // MARK: - Subviews
 
+    private var successView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            ZStack {
+                Circle()
+                    .fill(Color.primaryBrand.opacity(0.1))
+                    .frame(width: 88, height: 88)
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.primaryBrand)
+            }
+
+            VStack(spacing: 10) {
+                Text("Report submitted")
+                    .font(.custom("Poppins-Bold", size: 20))
+                    .foregroundColor(.textPrimary)
+
+                Text("Our team will review the reported situation. Thank you for helping keep the community safe.")
+                    .font(.custom("Poppins-Regular", size: 14))
+                    .foregroundColor(.textSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            Spacer()
+
+            Button("Close") { dismiss() }
+                .font(.custom("Poppins-SemiBold", size: 15))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.primaryBrand)
+                .foregroundColor(.white)
+                .cornerRadius(12)
+                .padding(.horizontal, 24)
+                .padding(.bottom, 16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
     private var categorySection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Categoría")
+            Text("Category")
                 .font(.custom("Poppins-SemiBold", size: 15))
                 .foregroundColor(.textPrimary)
 
@@ -71,7 +120,7 @@ struct ReportUserView: View {
 
     private var descriptionSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Descripción")
+            Text("Description")
                 .font(.custom("Poppins-SemiBold", size: 15))
                 .foregroundColor(.textPrimary)
 
@@ -84,7 +133,7 @@ struct ReportUserView: View {
                     )
 
                 if viewModel.description.isEmpty {
-                    Text("Describe brevemente lo ocurrido...")
+                    Text("Briefly describe what happened...")
                         .font(.custom("Poppins-Regular", size: 13))
                         .foregroundColor(.textSecondary)
                         .padding(12)
@@ -125,7 +174,7 @@ struct ReportUserView: View {
                 if viewModel.state == .loading {
                     ProgressView().tint(.white)
                 } else {
-                    Text("Enviar reporte")
+                    Text("Submit report")
                         .font(.custom("Poppins-SemiBold", size: 15))
                 }
             }

--- a/GN1Swift/Views/ReportUserView.swift
+++ b/GN1Swift/Views/ReportUserView.swift
@@ -1,0 +1,185 @@
+import SwiftUI
+
+struct ReportUserView: View {
+    let reportedUserId: String
+    let reportedUserName: String
+
+    @StateObject private var viewModel = ReportViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    private var isSubmitDisabled: Bool {
+        viewModel.description.trimmingCharacters(in: .whitespaces).count < 10
+            || viewModel.state == .loading
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.backgroundApp.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 24) {
+                        Text("Tu reporte será revisado por el equipo de UniRide. Provee información precisa para que podamos actuar.")
+                            .font(.custom("Poppins-Regular", size: 13))
+                            .foregroundColor(.textSecondary)
+                            .padding(.horizontal, 24)
+
+                        categorySection
+                        descriptionSection
+
+                        if case .failure(let msg) = viewModel.state {
+                            Text(msg)
+                                .font(.custom("Poppins-Regular", size: 12))
+                                .foregroundColor(.red)
+                                .padding(.horizontal, 24)
+                        }
+
+                        submitButton
+                    }
+                    .padding(.vertical, 16)
+                }
+            }
+            .navigationTitle("Reportar a \(reportedUserName)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") { dismiss() }
+                        .font(.custom("Poppins-Regular", size: 14))
+                        .foregroundColor(.primaryBrand)
+                }
+            }
+            .onChange(of: viewModel.state) { _, newState in
+                if case .success = newState { dismiss() }
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var categorySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Categoría")
+                .font(.custom("Poppins-SemiBold", size: 15))
+                .foregroundColor(.textPrimary)
+
+            ForEach(ReportCategory.allCases) { cat in
+                categoryRow(cat)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var descriptionSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Descripción")
+                .font(.custom("Poppins-SemiBold", size: 15))
+                .foregroundColor(.textPrimary)
+
+            ZStack(alignment: .topLeading) {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.surfaceCard)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.borderLine, lineWidth: 1)
+                    )
+
+                if viewModel.description.isEmpty {
+                    Text("Describe brevemente lo ocurrido...")
+                        .font(.custom("Poppins-Regular", size: 13))
+                        .foregroundColor(.textSecondary)
+                        .padding(12)
+                }
+
+                TextEditor(text: $viewModel.description)
+                    .font(.custom("Poppins-Regular", size: 13))
+                    .foregroundColor(.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .padding(8)
+                    .frame(minHeight: 100)
+                    .onChange(of: viewModel.description) { _, value in
+                        if value.count > 300 {
+                            viewModel.description = String(value.prefix(300))
+                        }
+                    }
+            }
+            .frame(minHeight: 120)
+
+            HStack {
+                Spacer()
+                Text("\(viewModel.description.count)/300")
+                    .font(.custom("Poppins-Regular", size: 11))
+                    .foregroundColor(.textSecondary)
+            }
+        }
+        .padding(.horizontal, 24)
+    }
+
+    private var submitButton: some View {
+        Button {
+            viewModel.submit(
+                reportedUserId: reportedUserId,
+                reportedUserName: reportedUserName
+            )
+        } label: {
+            HStack {
+                if viewModel.state == .loading {
+                    ProgressView().tint(.white)
+                } else {
+                    Text("Enviar reporte")
+                        .font(.custom("Poppins-SemiBold", size: 15))
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(
+                LinearGradient(
+                    colors: [Color.primaryBrand, Color.primaryBrand.opacity(0.8)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .opacity(isSubmitDisabled ? 0.5 : 1)
+            )
+            .foregroundColor(.white)
+            .cornerRadius(12)
+            .padding(.horizontal, 24)
+        }
+        .disabled(isSubmitDisabled)
+    }
+
+    @ViewBuilder
+    private func categoryRow(_ cat: ReportCategory) -> some View {
+        let isSelected = viewModel.category == cat
+        Button { viewModel.category = cat } label: {
+            HStack(spacing: 12) {
+                Image(systemName: cat.icon)
+                    .font(.system(size: 16))
+                    .foregroundColor(isSelected ? .primaryBrand : .textSecondary)
+                    .frame(width: 24)
+
+                Text(cat.displayName)
+                    .font(.custom("Poppins-Regular", size: 14))
+                    .foregroundColor(.textPrimary)
+
+                Spacer()
+
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.primaryBrand)
+                }
+            }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(isSelected ? Color.primaryBrand.opacity(0.1) : Color.surfaceCard)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(
+                                isSelected ? Color.primaryBrand.opacity(0.4) : Color.borderLine,
+                                lineWidth: 1
+                            )
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/GN1Swift/Views/UserProfileView.swift
+++ b/GN1Swift/Views/UserProfileView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+import FirebaseAuth
+
+struct UserProfileView: View {
+    let player: UserGamification
+
+    @State private var showingReport = false
+
+    private var isCurrentUser: Bool {
+        Auth.auth().currentUser?.uid == player.userId
+    }
+
+    var body: some View {
+        ZStack {
+            Color.backgroundApp.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: 20) {
+                    avatarHeader
+                    LevelProgressView(gamification: player)
+                        .padding(.horizontal, 24)
+                    StreakView(streakInfo: player.streakInfo)
+                        .padding(.horizontal, 24)
+                    badgesSection
+                    if !isCurrentUser {
+                        reportButton
+                    }
+                    Spacer().frame(height: 20)
+                }
+                .padding(.vertical, 16)
+            }
+        }
+        .navigationTitle("Perfil")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showingReport) {
+            ReportUserView(
+                reportedUserId: player.userId,
+                reportedUserName: player.displayName
+            )
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var avatarHeader: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: [Color.primaryBrand, Color.primaryBrand.opacity(0.6)],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 72, height: 72)
+
+                Text(String(player.displayName.prefix(1)).uppercased())
+                    .font(.custom("Poppins-Bold", size: 28))
+                    .foregroundColor(.white)
+            }
+
+            Text(player.displayName)
+                .font(.custom("Poppins-Bold", size: 20))
+                .foregroundColor(.textPrimary)
+
+            Text("Nivel \(player.level) · \(player.points) pts")
+                .font(.custom("Poppins-Regular", size: 13))
+                .foregroundColor(.textSecondary)
+        }
+        .padding(.top, 8)
+    }
+
+    @ViewBuilder
+    private var badgesSection: some View {
+        if !player.badges.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Badges")
+                        .font(.custom("Poppins-Bold", size: 16))
+                        .foregroundColor(.textPrimary)
+                    Spacer()
+                    Text("\(player.unlockedBadgesCount)/\(player.badges.count)")
+                        .font(.custom("Poppins-SemiBold", size: 13))
+                        .foregroundColor(.primaryBrand)
+                }
+
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 90))], spacing: 12) {
+                    ForEach(player.badges) { badge in
+                        BadgeView(badge: badge)
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+        }
+    }
+
+    private var reportButton: some View {
+        Button { showingReport = true } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "flag.fill")
+                    .font(.system(size: 14))
+                Text("Reportar usuario")
+                    .font(.custom("Poppins-SemiBold", size: 14))
+            }
+            .foregroundColor(.red)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 20)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.red.opacity(0.08))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color.red.opacity(0.3), lineWidth: 1)
+                    )
+            )
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 4)
+    }
+}

--- a/GN1Swift/Views/UserProfileView.swift
+++ b/GN1Swift/Views/UserProfileView.swift
@@ -35,7 +35,8 @@ struct UserProfileView: View {
         .sheet(isPresented: $showingReport) {
             ReportUserView(
                 reportedUserId: player.userId,
-                reportedUserName: player.displayName
+                reportedUserName: player.displayName,
+                source: .leaderboard
             )
         }
     }


### PR DESCRIPTION
The following points are the summary of the present pull request regarding the new report feature.

- UserProfileView: new screen accessed by tapping any leaderboard row, shows the player's avatar, level progress, streak and badges. Report button only appears when viewing another user's profile.

- ReportUserView: form with 5 categories (behavior, harassment, fake info, vehicle, other) and a description field (300 char limit). Shows a success screen on submission. Supports `ReportSource` enum for future entry points beyond the leaderboard.

- ReportViewModel: `@MainActor` class with offline persistence via UserDefaults — if the network fails, the report is saved locally and can be retried

- Firebase Cloud Function (`reportUser`): validates auth, rejects self-reports, enforces category and minimum description length, writes to reports collection with status: "pending"

- CommunityView: leaderboard rows wrapped in `NavigationLink` to `UserProfileView`

- AppFacade / CloudFunctionsService: wired `reportUser` through the existing facade pattern